### PR TITLE
Fix python 3 dict runtime error

### DIFF
--- a/flask_flaskwork.py
+++ b/flask_flaskwork.py
@@ -34,11 +34,7 @@ class Flaskwork(object):
         with self._request_lock:
             cutoff = datetime.datetime.now() - self.cleanup_interval
             if self._last_cleanup < cutoff:
-                deleted_items = []
-                for request_uuid, info in self._request_info.items():
-                    if info['timestamp'] < cutoff:
-                        del(self._request_info[request_uuid])
-                        deleted_items.append(request_uuid)
+                self._request_info = {key: value for key, value in self._request_info.items() if value['timestamp'] >= cutoff}
                 self._last_cleanup = datetime.datetime.now()
 
     def init_app(self, app):


### PR DESCRIPTION
In python 3 this occurs when method `_cleanup_request_info` run and `cleanup_interval` (300 seconds) has passed.
```
File "/Users/hugo/Documents/projects/flask-skeleton/.venv/lib/python3.6/site-packages/flask_flaskwork.py", line 38, in _cleanup_request_info
    for request_uuid, info in self._request_info.items():
RuntimeError: dictionary changed size during iteration
```

This is because `items()` returns a iterator in python 3 so the dict can't be modified while iterated.